### PR TITLE
Export necessary interface and class for customize http client implemendation

### DIFF
--- a/src/OpenKitBuilder.ts
+++ b/src/OpenKitBuilder.ts
@@ -41,6 +41,9 @@ const defaultDataCollectionLevel = DataCollectionLevel.UserBehavior;
 const defaultCrashReportingLevel = CrashReportingLevel.OptInCrashes;
 const defaultOperatingSystem = 'OpenKit';
 
+export * from './api';
+export * from './core';
+
 /**
  * Builder for an OpenKit instance.
  */

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,4 @@
+export { openKitVersion } from './PlatformConstants';
+export { HttpClient, HttpResponse } from './communication/http/HttpClient';
+export { HttpCommunicationChannel } from './communication/http/state/HttpCommunicationChannel';
+export { ConsoleLoggerFactory } from './logging/ConsoleLoggerFactory';


### PR DESCRIPTION
Some application doesn't support standard `fetch` api. such as Wechat Miniprogram.